### PR TITLE
feat: 加入排除 lable 的選項配置 (fix #7, #8)

### DIFF
--- a/.github/releaseter.yml
+++ b/.github/releaseter.yml
@@ -21,6 +21,7 @@ category-other:
 
 category-except-lables:
   - wont_release
+  - documentation
 
 clear-history-draft: true
 time-format: '060102 15:04:05'

--- a/.github/releaseter.yml
+++ b/.github/releaseter.yml
@@ -19,6 +19,9 @@ category-other:
   show: true
   title: 'OTHER'
 
+category-except-lables:
+  - wont_release
+
 clear-history-draft: true
 time-format: '060102 15:04:05'
 time-location: 'Asia/Taipei'

--- a/base/config.go
+++ b/base/config.go
@@ -32,10 +32,11 @@ type Config struct {
 	TagPreRelease string `yaml:"tag-preRelease"`
 	TagBuild      string `yaml:"tag-build"`
 
-	Categories    []*ConfigCategorie `yaml:"categories"`
-	CategoryOther *CategoryOther     `yaml:"category-other"`
-	TimeFormat    string             `yaml:"time-format"`
-	TimeLocation  string             `yaml:"time-location"`
+	Categories           []*ConfigCategorie `yaml:"categories"`
+	CategoryOther        *CategoryOther     `yaml:"category-other"`
+	CategoryExceptLables []string           `yaml:"category-except-lables"`
+	TimeFormat           string             `yaml:"time-format"`
+	TimeLocation         string             `yaml:"time-location"`
 
 	ClearHistoryDraft bool `yaml:"clear-history-draft"`
 

--- a/data/pull.go
+++ b/data/pull.go
@@ -29,6 +29,15 @@ func GetNewPullWithLables() model.LablePulls {
 			for _, pull := range pulls {
 
 				for _, label := range pull.Labels {
+					for _, exceptLable := range config.CategoryExceptLables {
+						if label.Name == exceptLable {
+							pull.NoRelease = true
+							continue foreachPulls
+						}
+					}
+				}
+
+				for _, label := range pull.Labels {
 
 					if label.Name == category.Label {
 						categoryPulls = append(categoryPulls, pull)
@@ -62,7 +71,7 @@ func GetNewPullWithLables() model.LablePulls {
 
 			otherPulls := make(model.Pulls, 0, 20)
 			for _, pull := range pulls {
-				if pull.Count == 0 {
+				if pull.Count == 0 && !pull.NoRelease {
 					otherPulls = append(otherPulls, pull)
 				}
 			}

--- a/data/pull.go
+++ b/data/pull.go
@@ -28,6 +28,10 @@ func GetNewPullWithLables() model.LablePulls {
 		foreachPulls:
 			for _, pull := range pulls {
 
+				if pull.NoRelease {
+					continue foreachPulls
+				}
+
 				for _, label := range pull.Labels {
 					for _, exceptLable := range config.CategoryExceptLables {
 						if label.Name == exceptLable {

--- a/model/pull.go
+++ b/model/pull.go
@@ -14,6 +14,7 @@ type GithubGetPull struct {
 	MergeCommitSHA string            `json:"merge_commit_sha"`
 	Labels         []*GithubGetLabel `json:"labels"`
 	Count          uint64
+	NoRelease      bool
 }
 
 type Pulls []*GithubGetPull


### PR DESCRIPTION
## What are you doing

有時候有些 PR 不想寫入 release，所以就新增了這個排除 lable 的選項 `category-except-lables`

```
category-except-lables:
  - xxx
  - ooo
```

這樣只要 pr 的 lable 有 `xxx` 或 `ooo` 就不會被新增至 release 中

## Testing

Please describe how you tested your changes.

<!--
    1. Test 1
    2. Test 2
    3. ...
-->

## Checklist

**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix
- [x] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [x] It's submitted to the `dev` branch
- [x] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)
- [x] My PR is based on the latest version of the `dev` branch.

## Other Information
